### PR TITLE
fix(eslint): remove prettier/@typescript-eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["plugin:adonis/typescriptApp", "prettier", "prettier/@typescript-eslint"],
+  "extends": ["plugin:adonis/typescriptApp", "prettier"],
   "plugins": ["prettier"],
   "rules": {
     "prettier/prettier": ["error"]


### PR DESCRIPTION
```
Error: "prettier/@typescript-eslint" has been merged into "prettier" in eslint-config-prettier 8.0.0. See: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21
```