### PR TITLE
fix transaction-client docs minor error

### DIFF
--- a/content/reference/database/transaction-client.md
+++ b/content/reference/database/transaction-client.md
@@ -8,10 +8,10 @@ You can access the transaction query client as follows:
 
 ```ts
 import Database from '@ioc:Adonis/Lucid/Database'
-await trx = await Database.transaction()
+const trx = await Database.transaction()
 
 // for a given connection
-await trx = await Database
+const trx = await Database
   .connection('pg')
   .transaction()
 ```


### PR DESCRIPTION
It was:
```ts
await trx = await Database.transaction()
```
now it is:
```ts
const trx = await Database.transaction()
```