### PR TITLE
Fix: response is not declared on controller's store method

### DIFF
--- a/content/cookbooks/validator/validating-server-rendered-forms.md
+++ b/content/cookbooks/validator/validating-server-rendered-forms.md
@@ -192,7 +192,7 @@ export default class PostsController {
   public async store({ request }: HttpContextContract) {
   // delete-end
   // insert-start
-  public async store({ request, session }: HttpContextContract) {
+  public async store({ request, session, response }: HttpContextContract) {
   // insert-end
 
     // ... Collpased existing code


### PR DESCRIPTION
``response`` variable is not declared inside the controller method. This will cause confusion to beginners.