### PR TITLE
FIXED Incorrect method name in Hashing Docs

### DIFF
--- a/content/guides/security/hashing.md
+++ b/content/guides/security/hashing.md
@@ -71,7 +71,7 @@ The `Hash.make` method accepts a string value to a hash.
 
 ```ts
 import Hash from '@ioc:Adonis/Core/Hash'
-const hashedPassword = await Hash.hash(user.password)
+const hashedPassword = await Hash.make(user.password)
 ```
 
 Most of the time, you will be hashing the user's password, so it is better to use a model hook to perform the hashing.


### PR DESCRIPTION
Updated docs to use correct `Hash.make` methods instead of previously incorrect `Hash.hash` method