### PR TITLE
Fix: missing brackets for csrfField helper

### DIFF
--- a/content/reference/views/globals/all-helpers.md
+++ b/content/reference/views/globals/all-helpers.md
@@ -53,7 +53,7 @@ Returns the hidden input element for the CSRF token. The helper is only availabl
 
 ```edge
 <form method="POST" action="posts">
-  {{ csrfField }}
+  {{ csrfField() }}
 </form>
 ```
 


### PR DESCRIPTION
Hey,
I'm trying AdonisJS and found this typo on the way 👍 