### PR TITLE
fix RouteParamMatcher

### DIFF
--- a/content/guides/http/routing.md
+++ b/content/guides/http/routing.md
@@ -215,7 +215,7 @@ However, you can manually cast the params to their actual JavaScript data type b
 Route
   .get('posts/:id', 'PostsController.show')
   .where('id', {
-    matches: ^/[0-9]+/$,
+    match: ^/[0-9]+/$,
     cast: (id) => Number(id),
   })
 ```


### PR DESCRIPTION
RouteParamMatcher has two properties, `match` and `cast`.

I'm aware the RegEx on this line is also incorrect but it's resolved in #24 