### PR TITLE
docs: use subpath exports to import core module

### DIFF
--- a/content/cookbooks/testing-adonisjs-apps.md
+++ b/content/cookbooks/testing-adonisjs-apps.md
@@ -126,7 +126,7 @@ process.env.ADONIS_ACE_CWD = join(__dirname)
 sourceMapSupport.install({ handleUncaughtExceptions: false })
 
 async function startHttpServer() {
-  const { Ignitor } = await import('@adonisjs/core/build/src/Ignitor')
+  const { Ignitor } = await import('@adonisjs/core/Ignitor')
   process.env.PORT = String(await getPort())
   await new Ignitor(__dirname).httpServer().start()
 }
@@ -269,7 +269,7 @@ async function rollbackMigrations() {
 // highlight-end
 
 async function startHttpServer() {
-  const { Ignitor } = await import('@adonisjs/core/build/src/Ignitor')
+  const { Ignitor } = await import('@adonisjs/core/Ignitor')
   process.env.PORT = String(await getPort())
   await new Ignitor(__dirname).httpServer().start()
 }

--- a/content/guides/digging-deeper/ace.md
+++ b/content/guides/digging-deeper/ace.md
@@ -75,7 +75,7 @@ node ace greet
 Ace commands are represented as classes and extend the `BaseCommand` class. You define the command name and description as static properties on the class itself.
 
 ```ts
-import { BaseCommand } from '@adonisjs/core/build/standalone'
+import { BaseCommand } from '@adonisjs/core/standalone'
 
 export default class Greet extends BaseCommand {
   public static commandName = 'greet'
@@ -205,7 +205,7 @@ import {
   BaseCommand,
   args,
   flags
-} from '@adonisjs/core/build/standalone'
+} from '@adonisjs/core/standalone'
 
 export default class Greet extends BaseCommand {
   public static commandName = 'greet'
@@ -275,7 +275,7 @@ public name: string
 The `@args.spread` method allows you to define a catch-all argument. It is like the [rest parameters ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) in JavaScript and must always be the last argument.
 
 ```ts
-import { BaseCommand, args } from '@adonisjs/core/build/standalone'
+import { BaseCommand, args } from '@adonisjs/core/standalone'
 
 export default class FileReader extends BaseCommand {
   public static commandName = 'read'
@@ -408,7 +408,7 @@ Ace has inbuilt support for creating interactive prompts on the terminal. You ca
 Following is an example of using multiple prompts together.
 
 ```ts
-import { BaseCommand } from '@adonisjs/core/build/standalone'
+import { BaseCommand } from '@adonisjs/core/standalone'
 
 export default class CreateUser extends BaseCommand {
   public static commandName = 'create:user'
@@ -728,7 +728,7 @@ Every time you run the `logUpdate` method, it will update the existing logline w
 Following is a complete working example of displaying a progress bar.
 
 ```ts
-import { BaseCommand } from '@adonisjs/core/build/standalone'
+import { BaseCommand } from '@adonisjs/core/standalone'
 
 export default class Greet extends BaseCommand {
   public static commandName = 'greet'
@@ -853,7 +853,7 @@ Ace has an inbuilt lightweight template generator. You can use it to generate fi
 
 ```ts
 import { join } from 'path'
-import { BaseCommand } from '@adonisjs/core/build/standalone'
+import { BaseCommand } from '@adonisjs/core/standalone'
 
 export default class Greet extends BaseCommand {
   public static commandName = 'greet'
@@ -991,7 +991,7 @@ The recommended approach is to execute the command in a separate child process. 
 // highlight-start
 import execa from 'execa'
 // highlight-end
-import { BaseCommand } from '@adonisjs/core/build/standalone'
+import { BaseCommand } from '@adonisjs/core/standalone'
 
 export default class Greet extends BaseCommand {
   public static commandName = 'greet'
@@ -1010,7 +1010,7 @@ export default class Greet extends BaseCommand {
 Another option is to make use of the Ace kernel to execute the command within the same process. In the following example, there is no way to know the exit code for the command.
 
 ```ts
-import { BaseCommand } from '@adonisjs/core/build/standalone'
+import { BaseCommand } from '@adonisjs/core/standalone'
 
 export default class Greet extends BaseCommand {
   public static commandName = 'greet'

--- a/content/guides/http/exception-handling.md
+++ b/content/guides/http/exception-handling.md
@@ -196,7 +196,7 @@ You can self-handle this exception by implementing the `handle` method on the ex
 
 ```ts
 // title: app/Exceptions/UnAuthorizedException.ts
-import { Exception } from '@adonisjs/core/build/standalone'
+import { Exception } from '@adonisjs/core/standalone'
 import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
 
 export default class UnAuthorizedException extends Exception {
@@ -212,7 +212,7 @@ Optionally, implement the `report` method to report the exception to a logging o
 
 ```ts
 // title: app/Exceptions/UnAuthorizedException.ts
-import { Exception } from '@adonisjs/core/build/standalone'
+import { Exception } from '@adonisjs/core/standalone'
 import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
 
 export default class UnAuthorizedException extends Exception {


### PR DESCRIPTION
This can only land after a release with https://github.com/adonisjs/core/pull/2796 is published.