### PR TITLE
Fixed `codeBlocksTheme` value

### DIFF
--- a/config/markdown.ts
+++ b/config/markdown.ts
@@ -40,7 +40,7 @@ export const markdownLanguages = [
 | Themes used for codeblocks
 |
 */
-export const codeBlocksTheme = 'material-theme-palenight'
+export const codeBlocksTheme = 'material-palenight'
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
It seems that `material-theme-palenight.json` is renamed to `material-palenight.json` in the [Shiki](https://github.com/shikijs/shiki) package.

front-end error:
```
'ENOENT: no such file or directory, open \'C:\\...\\docs.adonisjs.com\\node_modules\\shiki\\themes\\material-theme-palenight.json\''
```

typescript error:
```
Argument of type '"material-theme-palenight"' is not assignable to parameter of type 'Theme'.ts(2345)
(alias) const codeBlocksTheme: "material-theme-palenight"
```