### PR TITLE
fix: environment incorrect variable name example

### DIFF
--- a/content/guides/fundamentals/environment-variables.md
+++ b/content/guides/fundamentals/environment-variables.md
@@ -168,7 +168,7 @@ Forces the value to be one of the pre-defined values.
 
 // Mark it as optional
 {
-  PORT: Env
+  NODE_ENV: Env
     .schema
     .enum
     .optional(['development', 'production'] as const)


### PR DESCRIPTION
Hi,

For the second exemple, variable name should be "NODE_ENV" instead of "PORT"