### PR TITLE
Correct 'extname' value in Ace guide

### DIFF
--- a/content/guides/digging-deeper/ace.md
+++ b/content/guides/digging-deeper/ace.md
@@ -891,7 +891,7 @@ this.generator.addFile(
     form: 'plural',
 
     // define ".ts" extension when not already defined
-    extname: 'ts',
+    extname: '.ts',
 
     // re-format the name to "camelCase"
     pattern: 'camelcase',


### PR DESCRIPTION
While creating a command for myself, I discovered that the period is not prepended to the extension when the file is created, you have to add it yourself.