### PR TITLE
Update relationships.md

### DIFF
--- a/content/guides/models/relationships.md
+++ b/content/guides/models/relationships.md
@@ -301,6 +301,7 @@ export default class SkillUsers extends BaseSchema {
       // highlight-start
       table.integer('user_id').unsigned().references('users.id')
       table.integer('skill_id').unsigned().references('skills.id')
+      table.unique(['user_id', 'skill_id'])
       // highlight-end
       table.timestamp('created_at', { useTz: true })
       table.timestamp('updated_at', { useTz: true })


### PR DESCRIPTION
table.unique(['user_id', 'skill_id']) guarantees that there is only one pair of "user_id" and "skill_id" which is useful to avoid repeating. Refer to https://stackoverflow.com/questions/58710194/multiple-primary-keys-in-table-using-adonis-migration-nodejs