### PR TITLE
Fixed unneeded overflow x

### DIFF
--- a/resources/css/toc.css
+++ b/resources/css/toc.css
@@ -12,7 +12,7 @@ TOC BLOCK
   top: var(--header-height);
   bottom: 0;
   width: var(--toc-width);
-  overflow: scroll;
+  overflow-y: scroll;
   border-left: 1px solid var(--lighter-gray);
 }
 

--- a/resources/css/toc.css
+++ b/resources/css/toc.css
@@ -12,7 +12,7 @@ TOC BLOCK
   top: var(--header-height);
   bottom: 0;
   width: var(--toc-width);
-  overflow-y: scroll;
+  overflow-y: auto;
   border-left: 1px solid var(--lighter-gray);
 }
 


### PR DESCRIPTION
`overflow` property adds an empty scrollbar (from left to right). I replaced it with `overflow-y`

![Screenshot 2021-07-22 102915](https://user-images.githubusercontent.com/44144724/126682979-7d72489c-5428-4103-95dc-822646151467.png)
