### PR TITLE
fix(markdown): fix typo in models serialization

### DIFF
--- a/content/guides/models/serialization.md
+++ b/content/guides/models/serialization.md
@@ -326,7 +326,7 @@ const post = await Post
   .preload('author')
   .first()
 
-posts.serialize({
+post.serialize({
   fields: {
     pick: ['id', 'title', 'body'],
   },


### PR DESCRIPTION
`posts` must be singular in the example.