### PR TITLE
docs: added missing batch flag on migration rollback

### DIFF
--- a/content/cookbooks/testing-adonisjs-apps.md
+++ b/content/cookbooks/testing-adonisjs-apps.md
@@ -262,7 +262,7 @@ async function runMigrations() {
 }
 
 async function rollbackMigrations() {
-  await execa.node('ace', ['migration:rollback'], {
+  await execa.node('ace', ['migration:rollback', '--batch=0'], {
     stdio: 'inherit',
   })
 }


### PR DESCRIPTION
With the old code example, only the last migration will be rolled back.
To always have a clean database, the flag batch=0 has to be provided to the rollback command.