### PR TITLE
doc: Discord scope warning and warning block

### DIFF
--- a/content/guides/auth/social.md
+++ b/content/guides/auth/social.md
@@ -247,6 +247,13 @@ Also, for some of the drivers (e.g., Google), the list of the scopes is too long
 
 ![](https://res.cloudinary.com/adonis-js/image/upload/q_auto,f_auto/v1619637422/v5/ally-intellisense.jpg)
 
+:::warning
+
+If you want to customize the Discord driver, it require to have the `identify` scope present to work properly.
+You can find more informations about it [here](https://discord.com/developers/docs/resources/user#get-current-user).
+
+:::
+
 ## Define other query string params
 You can also define custom query string params on the redirect request using the `redirectRequest.param` method. For example: Define the `prompt` and the `access_type` for the Google provider.
 

--- a/content/guides/http/assets-manager.md
+++ b/content/guides/http/assets-manager.md
@@ -299,15 +299,15 @@ npm i -D @babel/preset-react
 
 Next, enable the react preset inside the `webpack.config.js` file.
 
-:::warn
+```ts
+Encore.enableReactPreset()
+```
+
+:::warning
 
 If you are using the `.babelrc` file, you must enable the react preset inside it, as Encore can no longer configure babel.
 
 :::
-
-```ts
-Encore.enableReactPreset()
-```
 
 ## Configuring Vue
 You can configure Vue by first enabling the vue loader inside the `webpack.config.js` file. 

--- a/content/guides/http/response.md
+++ b/content/guides/http/response.md
@@ -76,7 +76,7 @@ This approach ensures that the last call to `response.send` always wins. In most
 
 Following is an example of converting the `camelCase` object keys to `snake_case`.
 
-:::warn
+:::warning
 
 The following example is not the best way to transform response. It is just a demonstration of how post-processing a response looks like
 


### PR DESCRIPTION
PR linked with adonisjs/ally#128

I added a warning about the discord scope for people who want to customize them.
I also fixed some warning block by replacing `:::warn` to `:::warning` since it was the wrong syntax.