### PR TITLE
Fix docs hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <div align="center">
   <h3>AdonisJS official documentation</h3>
-  <p>Source code and documentation for the official documentation website hosted on [docs.adonisjs.com](https://docs.adonisjs.com)</p>
+  <p>Source code and documentation for the official documentation website hosted on <a href="https://docs.adonisjs.com">docs.adonisjs.com</a></p>
 </div>
 
 ## Setup


### PR DESCRIPTION
This PR updates docs link to work (look) as it should

Github doesn't render MD links correctly inside HTML. Have to use HTML tags for links to render correctly in HTML partions of markdown files


_I have no idea why it shows changes on line 150, changed nothing in there..._