### PR TITLE
[Fix] Fix typo on middleware.

### DIFF
--- a/content/guides/http/request.md
+++ b/content/guides/http/request.md
@@ -96,7 +96,7 @@ The request body is parsed using the pre-configured bodyparser middleware. Open 
 ```ts
 // title: start/kernel.ts
 Server.middleware.register([
-  () => import('@ioc:Adonis/Core/BodyParserMiddleware')
+  () => import('@ioc:Adonis/Core/BodyParser')
 ])
 ```
 


### PR DESCRIPTION
I spent 30 minutes trying to figure out why bodyparsermiddleware was not a thing. Realized you guys made a typo...

Now back coding.