### PR TITLE
Change the path in the asset helper method

### DIFF
--- a/content/guides/http/assets-manager.md
+++ b/content/guides/http/assets-manager.md
@@ -250,7 +250,7 @@ Encore.copyFiles({
 Also, make sure to use the `asset` helper to reference the image inside an `img` tag.
 
 ```edge
-<img src="{{ asset('logo.png') }}" />
+<img src="{{ asset('assets/images/logo.png') }}" />
 ```
 
 ## Configuring Babel


### PR DESCRIPTION
If you use the exact Encore.copyFiles method configuration as it is in the documentation currently:

`Encore.copyFiles({
  from: "./resources/images",
  to: "images/[path][name].[hash:8].[ext]",
})`

Then this won't work:

`<img src="{{ asset('logo.png') }}" />`

The actual image must be prefixed with the 'assets/images/' part.
So after updating it to:

`<img src="{{ asset('assets/images/logo.png') }}" />`

I finally got my images to work.
Someone else could get a bit confused by the documentation if not updated.