### PR TITLE
Updated many-to-many sync method docs

### DIFF
--- a/content/reference/orm/relations/many-to-many.md
+++ b/content/reference/orm/relations/many-to-many.md
@@ -547,14 +547,14 @@ await user
 
 In the above example, the `sync` method will only keep the projects with the mentioned ids and removes the other ones. 
 
-You can change this behavior by passing false to the second argument of sync method, then it will attach the given projects without deattach the others. This is usefull when you want to attach only if it's not already attached.
+You can change this behavior by passing false to the second argument of sync method, then it will attach the given projects without detaching the others. This is useful when you want to attach only if it's not already attached.
 
 ```ts
 await user
   .related('projects')
   .sync([1, 2],false)
 ```
-In the above example, the `sync` method will attach (only if they aren't already) the projects 1 and 2 without deattach the others.
+In the above example, the `sync` method will attach (only if they aren't already) the projects 1 and 2 without detaching the others.
 
 You can also perform a sync with pivot attributes.
 

--- a/content/reference/orm/relations/many-to-many.md
+++ b/content/reference/orm/relations/many-to-many.md
@@ -545,7 +545,18 @@ await user
   .sync([1, 2, 4, 5])
 ```
 
-In the above example, the `sync` method will only keep the projects with the mentioned ids and removes the other ones. You can also perform a sync with pivot attributes.
+In the above example, the `sync` method will only keep the projects with the mentioned ids and removes the other ones. 
+
+You can change this behavior by passing false to the second argument of sync method, then it will attach the given projects without deattach the others. This is usefull when you want to attach only if it's not already attached.
+
+```ts
+await user
+  .related('projects')
+  .sync([1, 2],false)
+```
+In the above example, the `sync` method will attach (only if they aren't already) the projects 1 and 2 without deattach the others.
+
+You can also perform a sync with pivot attributes.
 
 ```ts
 await user


### PR DESCRIPTION
Docs now shows an example of how to use a attach-without-dettach using false as a second argumento to the sync method