### PR TITLE
Fixing Route reference typo

### DIFF
--- a/content/guides/auth/web-guard.md
+++ b/content/guides/auth/web-guard.md
@@ -17,7 +17,7 @@ You can login the user using the `auth.attempt` or the `auth.login` method. The 
 - Otherwise an [InvalidCredentialsException](https://github.com/adonisjs/auth/blob/develop/src/Exceptions/InvalidCredentialsException.ts) is raised.
 
 ```ts
-import Route from '@ioc:Adonis/Core/Auth'
+import Route from '@ioc:Adonis/Core/Route'
 
 Route.post('login', async ({ auth, request, response }) => {
   const email = request.input('email')
@@ -43,7 +43,7 @@ If the `auth.attempt` lookup strategy does not fit your use case, then you can m
 
 ```ts
 import User from 'App/Models/User'
-import Route from '@ioc:Adonis/Core/Auth'
+import Route from '@ioc:Adonis/Core/Route'
 import Hash from '@ioc:Adonis/Core/Hash'
 
 Route.post('login', async ({ auth, request, response }) => {
@@ -101,7 +101,7 @@ The [AuthenticationException](https://github.com/adonisjs/auth/blob/develop/src/
 Otherwise, you can access the logged-in user using the `auth.user` property.
 
 ```ts
-import Route from '@ioc:Adonis/Core/Auth'
+import Route from '@ioc:Adonis/Core/Route'
 
 Route.get('dashboard', async ({ auth }) => {
   await auth.use('web').authenticate()
@@ -121,7 +121,7 @@ Calling this method manually inside every single route is not practical and henc
 You can logout the user by calling the `auth.logout` method. It will destroy the user login session and the remember me cookie. The remember me token inside the `users` is also set to null.
 
 ```ts
-import Route from '@ioc:Adonis/Core/Auth'
+import Route from '@ioc:Adonis/Core/Route'
 
 Route.post('/logout', async ({ auth, response }) => {
   await auth.use('web').logout()


### PR DESCRIPTION
Fixed typo issue for importing Route references on https://docs.adonisjs.com/guides/auth/web-guard