### PR TITLE
fix: small typo in `firstOrCreate` code example

### DIFF
--- a/content/reference/orm/base-model.md
+++ b/content/reference/orm/base-model.md
@@ -285,7 +285,7 @@ The `firstOrCreate` is similar to the `firstOrNew` method. However, instead of j
 The method accepts the same options as the [firstOrNew](#static-firstornew) method.
 
 ```ts
-const user = await User.firstOrNew(searchCriteria, savePayload)
+const user = await User.firstOrCreate(searchCriteria, savePayload)
 
 if (user.$isLocal) {
   // no rows found in db. Hence a new one is created


### PR DESCRIPTION
Encountered a small typo while documenting here: https://docs.adonisjs.com/reference/orm/base-model#static-firstorcreate
The code example was using the "firstOrNew" method instead of the "firstOrCreate" one.
Thanks for your work :slightly_smiling_face: 
Have a good day