### PR TITLE
fix: md format typo `** offset` to `**offset`

### DIFF
--- a/content/guides/database/pagination.md
+++ b/content/guides/database/pagination.md
@@ -2,7 +2,7 @@
 summary: Learn how to paginate results using the Lucid ORM
 ---
 
-Lucid has inbuilt support for ** offset-based pagination**. You can paginate the results of a query by chaining the `.paginate` method.
+Lucid has inbuilt support for **offset-based pagination**. You can paginate the results of a query by chaining the `.paginate` method.
 
 The `paginate` method accepts the page number as the first argument and the rows to fetch as the second argument. Internally, we execute an additional query to count the total number of rows.
 


### PR DESCRIPTION
# Description
Fix markdown format error/typo. There shouldn't be a space after double asterisks to make the word "offset-based pagination" bold.