### PR TITLE
Update the example of context i18n messages

### DIFF
--- a/content/guides/digging-deeper/i18n.md
+++ b/content/guides/digging-deeper/i18n.md
@@ -687,7 +687,7 @@ export default class ContactValidator {
   public schema = schema.create({})
 
   // highlight-start
-  public messages = this.ctx.i18n.validatorMessages('contact')
+  public messages = this.ctx.i18n.validatorMessages('validator.contact')
   // highlight-end
 }
 ```


### PR DESCRIPTION
The validator message fails to load with the example as it's now, but when adding "validator.contact" it works, so i update the example here.