### PR TITLE
[migrations] Fix incorrect commands

### DIFF
--- a/content/guides/database/migrations.md
+++ b/content/guides/database/migrations.md
@@ -333,7 +333,7 @@ The `migrator.migratedFiles` is an object. The key is the unique name (derived f
 - The `batch` property tells the batch in which the migration was executed.
 
 ### getList
-The `migrator.getList` method returns a list of all the migrations, including the completed and the pending ones. This is the same list you see when running the `node ace migration:list` command.
+The `migrator.getList` method returns a list of all the migrations, including the completed and the pending ones. This is the same list you see when running the `node ace migration:status` command.
 
 ```ts
 await migrator.getList()


### PR DESCRIPTION
There is no `node ace migration:list` command coming with AdonisJS, however `node ace migration:status` should be the command we are talking about in this guide.
![image](https://user-images.githubusercontent.com/61093863/142763994-cbdf2fcc-a834-40db-843c-3f9503b9ebb5.png)
