### PR TITLE
fix(mailer): fixed ts error

### DIFF
--- a/content/guides/digging-deeper/mailer.md
+++ b/content/guides/digging-deeper/mailer.md
@@ -634,7 +634,9 @@ Mailer can accept data using the constructor arguments. For example:
 ```ts
 export default class VerifyEmail extends BaseMailer {
   // highlight-start
-  constructor (private user: User) {}
+  constructor (private user: User) {
+    super()
+  }
   // highlight-end
 
   public prepare(message: MessageContract) {


### PR DESCRIPTION
Without `super()` TS will show following error 

`Constructors for derived classes must contain a 'super' call.` 