### PR TITLE
docs: update http request docs charset as charsets

### DIFF
--- a/content/guides/http/request.md
+++ b/content/guides/http/request.md
@@ -501,8 +501,8 @@ return Buffer.from('hello-world').toString(charset || 'utf-8')
 
 ---
 
-### charset
-The `charset` method returns an array of accepted charsets by inspecting the `Accept-charset` header. The array is ordered by the client's preference (most preferred first).
+### charsets
+The `charsets` method returns an array of accepted charsets by inspecting the `Accept-charset` header. The array is ordered by the client's preference (most preferred first).
 
 ```ts
 const charsets = request.charsets()


### PR DESCRIPTION
Find a mistake when I read guides:

![image](https://user-images.githubusercontent.com/30547306/149084230-7d93eac7-9347-4c05-b621-6bf15157f495.png)



