### PR TITLE
Added response's clear cookie method to cookie guide

### DIFF
--- a/content/guides/http/cookies.md
+++ b/content/guides/http/cookies.md
@@ -2,7 +2,7 @@
 summary: A reference to reading and writing cookies during the HTTP requests.
 ---
 
-You work with cookies using the [request](./request.md) and the [response](./response.md) classes. The request class exposes the API for reading the existing cookies, and the response class allows creating/updating cookies.
+You work with cookies using the [request](./request.md) and the [response](./response.md) classes. The request class exposes the API for reading the existing cookies, and the response class allows creating, updating and deleting cookies.
 
 ```ts
 import Route from '@ioc:Adonis/Core/Route'
@@ -18,6 +18,13 @@ Route.post('add-to-cart', async ({ request, response }) => {
    */
   const newItems = existingItems.concat([{ id: 10 }])
   response.cookie('cart-items', newItems)
+})
+
+Route.delete('clear-cart', async ({ response }) => {
+  /**
+   * Clear cookie
+   */
+  response.clearCookie('cart-items')
 })
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "docs.adonisjs.com",
       "version": "1.0.0",
       "dependencies": {
         "@adonisjs/core": "^5.4.0",


### PR DESCRIPTION
This PR will add a response's clear cookie method on the [http cookie guide](https://docs.adonisjs.com/guides/cookies) page.