### PR TITLE
docs: add note about rules.required() not necessary by defaullt

### DIFF
--- a/content/guides/validator/introduction.md
+++ b/content/guides/validator/introduction.md
@@ -50,6 +50,10 @@ If you look carefully, we have separated the **format validations** from **core 
 
 This separation helps extend the validator with custom rules without creating unnecessary schema types that have no meaning. For example, there is no thing called **email type**; it is just a string, formatted as an email.
 
+:::note
+Fields are required by default and hence there is no need to use `rules.required` method. Using it would result in duplicate error messages.
+:::
+
 ## Working with optional and null values
 The validator schema has first-class support for marking values as optional and null using the modifier functions. 
 


### PR DESCRIPTION
I ran into the issue of using ``rules.required()`` in my validation and got duplicate error messages. In reference to [this](https://github.com/adonisjs/core/discussions/2782) discussion, I think it should be added to the docs.