### PR TITLE
fix: align search icon with dark mode icon

### DIFF
--- a/resources/css/header.css
+++ b/resources/css/header.css
@@ -72,7 +72,7 @@ HEADER STYLES
   width: var(--toc-width);
   padding: 0 var(--space-x) 0 10px;
   border-left: 1px solid var(--brand-mute-color);
-  margin: auto;
+  margin-block: auto;
 }
 
 .search-trigger {

--- a/resources/css/header.css
+++ b/resources/css/header.css
@@ -72,6 +72,7 @@ HEADER STYLES
   width: var(--toc-width);
   padding: 0 var(--space-x) 0 10px;
   border-left: 1px solid var(--brand-mute-color);
+  margin: auto;
 }
 
 .search-trigger {


### PR DESCRIPTION
Sorry to create a PR for this but I still don't have write permission on this repo 😅

Before : 
![image](https://user-images.githubusercontent.com/8337858/158245258-8af2e37a-6267-4c94-97d5-1cdf801b4ba0.png)

After : 
![image](https://user-images.githubusercontent.com/8337858/158245283-9926992e-fe10-4592-9923-e3ca5c8f71b2.png)

