### PR TITLE
fix: Fix broken link in BelongsTo page

### DIFF
--- a/content/reference/orm/relations/belongs-to.md
+++ b/content/reference/orm/relations/belongs-to.md
@@ -2,7 +2,7 @@
 summary: API documentation for Lucid BelongsTo relationship
 ---
 
-The [BelongsTo relationship class](https://github.com/adonisjs/lucid/blob/develop/src/Orm/Relations/BelongsTo.ts) manages the belongs to the relationship between two models.
+The [BelongsTo relationship class](https://github.com/adonisjs/lucid/blob/develop/src/Orm/Relations/BelongsTo/index.ts) manages the belongs to the relationship between two models.
 
 You will not find yourself directly working with this class. However, an instance of the class can be accessed using the `Model.$getRelation` method.
 


### PR DESCRIPTION
### Fix broken link in BelongsTo page

I just noticed that the `.../BelongsTo.ts` do not exist anymore, and I think the right reference is `.../BelongsTo/index.ts`.

I could have opened an issue, but since this is as simple as locating the file and correcting the link, I did it myself.
Hope that's the correct link.