### PR TITLE
docs: add comment in `config/drive.ts` for minio

### DIFF
--- a/content/guides/digging-deeper/drive.md
+++ b/content/guides/digging-deeper/drive.md
@@ -61,6 +61,9 @@ const driveConfig: DriveConfig = {
       region: Env.get('S3_REGION'),
       bucket: Env.get('S3_BUCKET'),
       endpoint: Env.get('S3_ENDPOINT'),
+      
+      // For minio to work
+      // forcePathStyle: true,
     },
   },
 }


### PR DESCRIPTION
Self hosted minio won't work if we don't add `forcePathStyle` option.

Reference:
https://docs.min.io/docs/how-to-use-aws-sdk-for-javascript-with-minio-server.html

```diff
var AWS = require('aws-sdk');

var s3  = new AWS.S3({
          accessKeyId: 'YOUR-ACCESSKEYID' ,
          secretAccessKey: 'YOUR-SECRETACCESSKEY' ,
          endpoint: 'http://127.0.0.1:9000' ,
+          s3ForcePathStyle: true, // needed with minio?
          signatureVersion: 'v4'
});
```
