### PR TITLE
docs(testing): fix multiple suites example + add an example with multiple tags parameters

### DIFF
--- a/content/guides/testing/introduction.md
+++ b/content/guides/testing/introduction.md
@@ -170,7 +170,10 @@ node ace test
 node ace test functional
 
 # unit and functional tests are executed sequentially
-node ace test unit,functional
+node ace test unit functional
+
+# Only tests with an "orders" or "upload" tag in the "unit" and "functional" suites
+node ace test --tags=orders,upload unit functional
 ```
 
 The `test` command accepts the following flags.

--- a/content/guides/testing/introduction.md
+++ b/content/guides/testing/introduction.md
@@ -173,7 +173,7 @@ node ace test functional
 node ace test unit functional
 
 # Only tests with an "orders" or "upload" tag in the "unit" and "functional" suites
-node ace test --tags=orders,upload unit functional
+node ace test --tags="orders,upload" unit functional
 ```
 
 The `test` command accepts the following flags.


### PR DESCRIPTION
- Should be `node ace test unit functional`, not `node ace test unit,functional`
- Added an example of an array parameter ( `tags` for the example ), so that people understand how it works