### PR TITLE
Replaced `badRequest` with `unauthorized` in api-tokens-guard.md

### DIFF
--- a/content/guides/auth/api-tokens-guard.md
+++ b/content/guides/auth/api-tokens-guard.md
@@ -128,7 +128,7 @@ Route.post('login', async ({ auth, request, response }) => {
     return token
     // highlight-end
   } catch {
-    return response.badRequest('Invalid credentials')
+    return response.unauthorized('Invalid credentials')
   }
 })
 ```
@@ -165,7 +165,7 @@ Route.post('login', async ({ auth, request, response }) => {
 
   // Verify password
   if (!(await Hash.verify(user.password, password))) {
-    return response.badRequest('Invalid credentials')
+    return response.unauthorized('Invalid credentials')
   }
 
   // Generate token


### PR DESCRIPTION
I replaced `badRequest` with `unauthorized`.

According to w3.org:
> [10.4.1 400 Bad Request](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1)
> The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modifications.
> 
> [10.4.2 401 Unauthorized](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2)
> The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource. The client MAY repeat the request with a suitable Authorization header field (section [14.8](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.8)). If the request already included Authorization credentials, then the 401 response indicates that authorization has been refused for those credentials. If the 401 response contains the same challenge as the prior response, and the user agent has already attempted authentication at least once, then the user SHOULD be presented the entity that was given in the response, since that entity might include relevant diagnostic information. HTTP access authentication is explained in "HTTP Authentication: Basic and Digest Access Authentication" [[43]](https://www.w3.org/Protocols/rfc2616/rfc2616-sec17.html#bib43).