### PR TITLE
Fix 404 link for preload

### DIFF
--- a/content/cookbooks/database/using-knex-postgis-with-lucid.md
+++ b/content/cookbooks/database/using-knex-postgis-with-lucid.md
@@ -25,7 +25,7 @@ const st = knexPostgis(db)
 
 Since the management of connections is abstracted with Lucid, we need a graceful API to grab the `st` object for any connection on-demand.
 
-We can do this by extending the Database class and adding an `st` method to it. For the sake of simplicity, I will write the following code inside a [preload file.](./../guides/fundamentals/adonisrc-file.md)
+We can do this by extending the Database class and adding an `st` method to it. For the sake of simplicity, I will write the following code inside a [preload file.](./../../guides/http/routing.md#register-as-a-preload-file)
 
 ```ts
 // title: start/db.ts


### PR DESCRIPTION
The current link for preload give 404 https://docs.adonisjs.com/guides/fundamentals/adonisrc-file.md

<img width="1434" alt="image" src="https://user-images.githubusercontent.com/15819498/171466726-cc0dc231-4283-4c0c-81c7-c6dd6866a0be.png">
