### PR TITLE
There is no mailer.size() method

### DIFF
--- a/content/guides/testing/fakes.md
+++ b/content/guides/testing/fakes.md
@@ -23,7 +23,6 @@ test('register user', async ({ assert, client }) => {
 
   // highlight-start
   // Time for assertions
-  assert.lengthOf(mailer.size(), 1)
   assert.isTrue(mailer.exists((mail) => {
     return mail.subject === 'Welcome to AdonisJS'
   }))


### PR DESCRIPTION
Removed mention from docs so copy+paste works without errors.