### PR TITLE
Update api-tokens-guard.md

### DIFF
--- a/content/guides/auth/api-tokens-guard.md
+++ b/content/guides/auth/api-tokens-guard.md
@@ -180,11 +180,11 @@ You can also define the expiry for the token at the time of the generating it.
 
 ```ts
 await auth.use('api').attempt(email, password, {
-  expiresIn: '7days'
+  expiresIn: '7 days'
 })
 
 await auth.use('api').generate(user, {
-  expiresIn: '30mins'
+  expiresIn: '30 mins'
 })
 ```
 


### PR DESCRIPTION
Package ms that is used to translate interval times uses a space to separate the amount and the magnitude.

<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

https://github.com/adonisjs/auth/issues/202#issuecomment-1222755598

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As specified in docs, to set expiresIn option in auth module, you need to use this syntax: 3mins or 2days but as shown in ms docs it is wrong.

https://www.npmjs.com/package/ms

A space is needed between amount and magnitude.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
