### PR TITLE
renamed references to "serveAssets" to "serveFiles"

### DIFF
--- a/content/guides/digging-deeper/drive.md
+++ b/content/guides/digging-deeper/drive.md
@@ -52,7 +52,7 @@ export default driveConfig({
       visibility: 'public',
       root: Application.tmpPath('uploads'),
       basePath: '/uploads',
-      serveAssets: true,
+      serveFiles: true,
     },
 
     s3: {
@@ -108,7 +108,7 @@ Ensure you do not define any other routes in your application using the same pre
 ```ts
 local: {
   basePath: '/uploads',
-  serveAssets: true,
+  serveFiles: true,
 }
 ```
 
@@ -326,14 +326,14 @@ You can generate a URL to a file path using the `Drive.getUrl` or the `Drive.get
 
 In the case of cloud storage providers, the generated URL points to the cloud service. Whereas, in the case of the `local` driver, the URL points to your AdonisJS application.
 
-The `local` driver registers a route implicitly when the `serveAssets` option is set to true inside the config file. Also, a `basePath` is required and must be unique across the registered disks.
+The `local` driver registers a route implicitly when the `serveFiles` option is set to true inside the config file. Also, a `basePath` is required and must be unique across the registered disks.
 
 ```ts
 {
   local: {
     driver: 'local',
     // highlight-start
-    serveAssets: true,
+    serveFiles: true,
     basePath: '/uploads'
     // highlight-end
   }


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

[Issue #180 ](https://github.com/adonisjs/docs.adonisjs.com/issues/180)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Hi, I've corrected all lines that referenced "serveAssets" to "serveFiles".

Resolves #180 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

Updated [content/guides/digging-deeper/drive.md](https://github.com/adonisjs/docs.adonisjs.com/compare/develop...rokaicker:docs.adonisjs.com:issue-180?expand=1#diff-bbda60a3a037f3032d1bbab22d6570e616a3fb863e14987716fa867fa02dc16f)