### PR TITLE
docs: remove of deprecated property 'developmentOnly'

### DIFF
--- a/content/guides/database/seeders.md
+++ b/content/guides/database/seeders.md
@@ -213,10 +213,13 @@ import Application from '@ioc:Adonis/Core/Application'
 export default class IndexSeeder extends BaseSeeder {
   private async runSeeder(Seeder: { default: typeof BaseSeeder }) {
     /**
-     * Do not run when not in dev mode and seeder is development
-     * only
+     * Do not run when not in a environment specified in Seeder
      */
-    if (Seeder.default.developmentOnly && !Application.inDev) {
+    if (
+      (!Seeder.default.environment.includes('development') && Application.inDev)
+      || (!Seeder.default.environment.includes('testing') && Application.inTest)
+      || (!Seeder.default.environment.includes('production') && Application.inProduction)
+    ) {
       return
     }
 


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The *developmentOnly* property is deprecated, but was being used in the **Customizing seeder order** section.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.