### PR TITLE
docs: remove first object parameter from string validator

### DIFF
--- a/content/guides/validator/custom-rules.md
+++ b/content/guides/validator/custom-rules.md
@@ -65,7 +65,7 @@ import { rules, schema, validator } from '@ioc:Adonis/Core/Validator'
 
 await validator.validate({
   schema: schema.create({
-    fileName: schema.string({}, [
+    fileName: schema.string([
       // highlight-start
       rules.camelCase()
       // highlight-end

--- a/content/reference/validator/rules/equal-to.md
+++ b/content/reference/validator/rules/equal-to.md
@@ -4,7 +4,7 @@ Validates the value to be equal to a provided value.
 import { schema, rules } from '@ioc:Adonis/Core/Validator'
 
 {
-  country: schema.string({}, [
+  country: schema.string([
     rules.equalTo('IN')
   ])
 }
@@ -25,7 +25,7 @@ export default class CreateUserValidator {
   })
 
   public schema = schema.create({
-    country: schema.string({}, [
+    country: schema.string([
       rules.equalTo(this.refs.teamsCountry)
     ]),
   })

--- a/content/reference/validator/rules/exists.md
+++ b/content/reference/validator/rules/exists.md
@@ -10,7 +10,7 @@ The validation rule is added by `@adonisjs/lucid` package. So make sure it is [i
 import { schema, rules } from '@ioc:Adonis/Core/Validator'
 
 {
-  slug: schema.string({}, [
+  slug: schema.string([
     rules.exists({ table: 'categories', column: 'slug' })
   ])
 }
@@ -22,7 +22,7 @@ Many databases perform case sensitive queries. So either you can transform the v
 
 ```ts
 {
-  username: schema.string({}, [
+  username: schema.string([
     rules.exists({
       table: 'users',
       column: 'username',
@@ -44,7 +44,7 @@ Additionally, you can also define `where` and `whereNot` constraints as an objec
 
 ```ts
 {
-  slug: schema.string({}, [
+  slug: schema.string([
     rules.exists({
       table: 'categories',
       column: 'slug',
@@ -105,7 +105,7 @@ export default class CreateUserValidator {
   // highlight-end
 
   public schema = schema.create({
-    username: schema.string({}, [
+    username: schema.string([
       rules.exists({
         table: 'users',
         column: 'username',

--- a/content/reference/validator/rules/ip.md
+++ b/content/reference/validator/rules/ip.md
@@ -4,7 +4,7 @@ Validates the value to be a valid IP address. Optionally, you can also enforce t
 import { schema, rules } from '@ioc:Adonis/Core/Validator'
 
 {
-  ip: schema.string({}, [
+  ip: schema.string([
     rules.ip()
   ])
 }
@@ -12,7 +12,7 @@ import { schema, rules } from '@ioc:Adonis/Core/Validator'
 
 ```ts
 {
-  ip: schema.string({}, [
+  ip: schema.string([
     rules.ip({ version: 6 })
   ])
 }

--- a/content/reference/validator/rules/max-length.md
+++ b/content/reference/validator/rules/max-length.md
@@ -6,7 +6,7 @@ In the following example, the username with greater than 40 characters will fail
 import { schema, rules } from '@ioc:Adonis/Core/Validator'
 
 {
-  username: schema.string({}, [
+  username: schema.string([
     rules.maxLength(40)
   ])
 }

--- a/content/reference/validator/rules/min-length.md
+++ b/content/reference/validator/rules/min-length.md
@@ -6,7 +6,7 @@ In the following example, the username with less than 4 characters will fail the
 import { schema, rules } from '@ioc:Adonis/Core/Validator'
 
 {
-  username: schema.string({}, [
+  username: schema.string([
     rules.minLength(4)
   ])
 }

--- a/content/reference/validator/rules/unique.md
+++ b/content/reference/validator/rules/unique.md
@@ -10,7 +10,7 @@ The validation rule is added by `@adonisjs/lucid` package. So make sure it is [i
 import { schema, rules } from '@ioc:Adonis/Core/Validator'
 
 {
-  email: schema.string({}, [
+  email: schema.string([
     rules.unique({ table: 'users', column: 'email' })
   ])
 }
@@ -22,7 +22,7 @@ Many databases perform case sensitive queries. So either you can transform the v
 
 ```ts
 {
-  email: schema.string({}, [
+  email: schema.string([
     rules.unique({
       table: 'users',
       column: 'email',
@@ -44,7 +44,7 @@ Additionally, you can also define `where` and `whereNot` constraints as an objec
 
 ```ts
 {
-  email: schema.string({}, [
+  email: schema.string([
     rules.unique({
       table: 'users',
       column: 'email',
@@ -101,7 +101,7 @@ export default class CreateUserValidator {
   // highlight-end
 
   public schema = schema.create({
-    email: schema.string({}, [
+    email: schema.string([
       rules.unique({
         table: 'users',
         column: 'email',

--- a/content/releases/august-2020-release.md
+++ b/content/releases/august-2020-release.md
@@ -104,7 +104,7 @@ The `blacklist` rule dis-allows certain values. It is the opposite of the enum s
 
 ```ts
 {
-  username: schema.string({}, [
+  username: schema.string([
     rules.blacklist([
       'super',
       'admin',

--- a/content/releases/out-of-preview.md
+++ b/content/releases/out-of-preview.md
@@ -323,7 +323,7 @@ The `blacklist` rule has been renamed to `notIn`
 
 ```ts
 {
-  username: schema.string({}, [
+  username: schema.string([
     // delete-start
     rules.blacklist(['admin', 'super'])
     // delete-end
@@ -338,7 +338,7 @@ The `hostWhitelist` and `hostBlacklist` properties of the `url` validation rules
 
 ```ts
 {
-  twitterHandle: schema.string({}, [
+  twitterHandle: schema.string([
     rules.url({
       // delete-start
       hostWhitelist: ['twitter']


### PR DESCRIPTION
If I'm not mistaken, the empty object we use as a first parameter is useless after the April 2022 update as we are encouraged to use trim or escape in the array.

https://docs.adonisjs.com/releases/april-2022-release#validator-improvements
