### PR TITLE
docs: fix typo in mobile validator rule

### DIFF
--- a/content/reference/validator/rules/mobile.md
+++ b/content/reference/validator/rules/mobile.md
@@ -16,7 +16,7 @@ You can also specify one or more locales to force format validation for a specif
 {
   mobile: schema.string([
     rules.mobile({
-      locales: ['pt-BR', 'en-IN', 'en-US']
+      locale: ['pt-BR', 'en-IN', 'en-US']
     })
   ])
 }


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed typo in mobile validator rule arguments:

https://github.com/adonisjs/validator/blob/b00a2cfe6408fbfe9d99cd17b4f79cb63363a2eb/src/Validations/string/mobile.ts#L29

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
