### PR TITLE
docs: add edit page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ CACHE_VIEWS=false
 DEBUG_DOCS=true
 ALGOLIA_API_KEY=
 COPY_REDIRECTS_FILE=false
+REPOSITORY_URL=https://github.com/adonisjs/docs.adonisjs.com
 ```
 
 The `ALGOLIA_API_KEY` environment variable is optional and required only if you want to enable search.

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -166,6 +166,20 @@ html.dark .sponsor a:hover img {
   filter: none;
 }
 
+.edit-link {
+  color: var(--edit-link-color);
+}
+
+.edit-link .edit-icon {
+  position: relative;
+  top: 2px;
+}
+
+.edit-link a {
+  font-size: 16px;
+  text-decoration: none;
+}
+
 @media (min-width: 1280px) {
   .sponsors {
     flex-direction: row;

--- a/resources/css/dark-variables.css
+++ b/resources/css/dark-variables.css
@@ -18,6 +18,7 @@ html.dark {
   --toc-border-color: rgb(77 77 77 / 50%);
   --toc-text-color: var(--mute-color);
   --sidebar-selected-text: var(--accent-color);
+  --edit-link-color: var(--accent-color);
 
   --carbon-ads-bg-color: rgb(33 33 33);
   --carbon-background-text: #e2e2e2;

--- a/resources/css/variables.css
+++ b/resources/css/variables.css
@@ -18,6 +18,7 @@
   --pre-header-color: #b3b3d0;
   --toc-border-color: #d1d5db;
   --toc-text-color: var(--light-gray);
+  --edit-link-color: var(--brand-color);
 
   --carbon-ads-bg-color: #f7f8fb;
   --carbon-ads-text: #454f5b;

--- a/resources/views/partials/doc.edge
+++ b/resources/views/partials/doc.edge
@@ -17,5 +17,16 @@
     @endif
 
     @dimerTree(file.ast.children)~
+
+    <hr>
+
+    <p class="edit-link">
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="edit-icon">
+        <path d="M20 14.66V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5.34"></path>
+        <polygon points="18 2 22 6 12 16 8 16 8 12 18 2"></polygon>
+      </svg>
+
+      <a href="{{ env('REPOSITORY_URL') }}/blob/develop/content{{ doc.url }}.md" target="_blank">Edit this page on GitHub</a>
+    </p>
   </div>
 </main>


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

It has been asked on Discord: https://discord.com/channels/423256550564691970/1092813414939775129

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hey!

This PR adds an "Edit this page on GitHub" link at the bottom of each page.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
