### PR TITLE
fix: use file path instead of page url to get the correct link

### DIFF
--- a/env.ts
+++ b/env.ts
@@ -22,4 +22,5 @@ export default Env.rules({
   CACHE_VIEWS: Env.schema.boolean(),
   NODE_ENV: Env.schema.enum(['development', 'production', 'testing'] as const),
   COPY_REDIRECTS_FILE: Env.schema.boolean.optional(),
+  REPOSITORY_URL: Env.schema.string({ format: 'url' }),
 })

--- a/resources/views/partials/doc.edge
+++ b/resources/views/partials/doc.edge
@@ -26,7 +26,7 @@
         <polygon points="18 2 22 6 12 16 8 16 8 12 18 2"></polygon>
       </svg>
 
-      <a href="{{ env('REPOSITORY_URL') }}/blob/develop/content{{ doc.url }}.md" target="_blank">Edit this page on GitHub</a>
+      <a href="{{ env('REPOSITORY_URL') }}/blob/develop{{ doc.path.replace(app.appRoot, '') }}" target="_blank">Edit this page on GitHub</a>
     </p>
   </div>
 </main>


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

The previous PR (#207) introduced a new link at the bottom of each page to make it easy to contribute to improve the docs. However, it worked only for non-nested pages (i.e: Introduction, Installation and Release process) and nested pages led to a 404 error. This PR fixes this bug by using the file path (of the page) instead of its URL to get the correct link.

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
