### PR TITLE
Docs: Update section closing tag

### DIFF
--- a/content/guides/views/layouts.md
+++ b/content/guides/views/layouts.md
@@ -60,7 +60,7 @@ Let's create a standard webpage using layouts.
       </p>
     </div>
   </section>
-@end
+@endsection
 ```
 
 #### 4. Render the view, and you will end up with the following result
@@ -87,7 +87,7 @@ In the following example, the layout renders the scripts tags inside the `script
 @section('scripts')
   <script src="./vendor.js"></script>
   <script src="./app.js"></script>
-@end
+@endsection
 ```
 
 #### Parent template overriding everything
@@ -96,7 +96,7 @@ In the following example, the layout renders the scripts tags inside the `script
 @section('scripts')
   <script src="./vendor.js"></script>
   <script src="./admin.js"></script>
-@end
+@endsection
 ```
 
 #### Parent template appending to existing scripts
@@ -105,7 +105,7 @@ In the following example, the layout renders the scripts tags inside the `script
 @section('scripts')
   @super {{-- Super means inherit --}}
   <script src="./autocomplete.js"></script>
-@end
+@endsection
 ```
 
 - The name for all the section tags must be unique.


### PR DESCRIPTION
I got an error when following the documentation.

Use `@endsection` when closing a `@section`, not `@end`.

```
InvalidTemplateException: lineno:3 charno:1 E_UNCLOSED_TAG: Unclosed (section) tag found as <@section('content')> statement. Make sure to close it as (endsection)
    at InvalidTemplateException.unClosedTag (/Users/xxx/xxx/xxx/xxx/node_modules/edge.js/src/Exceptions/index.js:139:19)
```