### PR TITLE
docs: fix typos

### DIFF
--- a/content/cookbooks/auth/using-ally-with-api-guard.md
+++ b/content/cookbooks/auth/using-ally-with-api-guard.md
@@ -87,7 +87,7 @@ import User from 'App/Models/User'
 
 Route.get('/:provider/callback', async ({ ally, auth, response, params }) => {
   /**
-   * If user is alrady logged in, do not execute the callback.
+   * If user is already logged in, do not execute the callback.
    */
   if (await auth.check()) {
     return response.notAcceptable()

--- a/content/cookbooks/database/using-postgres-custom-type-parsers.md
+++ b/content/cookbooks/database/using-postgres-custom-type-parsers.md
@@ -65,7 +65,7 @@ export default class AppProvider {
 }
 ```
 
-## Make driver autmatically use BigInt for BIGINT + BIGSERIAL
+## Make driver automatically use BigInt for BIGINT + BIGSERIAL
 
 One more example is how we can utilise this to convert BIGINT and BIGSERIAL PostgreSQL types to JavaScript BigInt:
 

--- a/content/cookbooks/deployment/laravel-forge.md
+++ b/content/cookbooks/deployment/laravel-forge.md
@@ -23,7 +23,7 @@ npm run build
 
 ## Create a Server
 
-Select your prefered provider and create a server
+Select your preferred provider and create a server
 
 Once server is ready . Create a database user (optional)
 
@@ -47,7 +47,7 @@ When you create a server on forge , we need to create a [site](https://forge.lar
 
 ### Configure Your Deployment script and Git settings
 
-Deploy Script is the commands that are executed when you push a commit to your pre-defined branch . in our case for Adonisjs we need to access the app folder -> then pull the changes -> run some commands for migration and build proccess . 
+Deploy Script is the commands that are executed when you push a commit to your pre-defined branch . in our case for Adonisjs we need to access the app folder -> then pull the changes -> run some commands for migration and build process . 
 
 
  "Quick Deploy" feature allows you to easily deploy your projects when you push to your source control provider. When you push to your configured quick deploy branch, Forge will pull your latest code from source control and run your application's configured deployment script.

--- a/content/cookbooks/testing-adonisjs-apps.md
+++ b/content/cookbooks/testing-adonisjs-apps.md
@@ -2,7 +2,7 @@
 datetime: 2020-06-24
 author: Virk
 avatarUrl: https://res.cloudinary.com/adonis-js/image/upload/v1619103621/adonisjs-authors-avatars/DYO4KUru_400x400_shujhw.jpg
-summary: Setting up the Japa test runner to test AdonisJS appplication
+summary: Setting up the Japa test runner to test AdonisJS application
 ---
 
 The tests runner of AdonisJS v4 has not been migrated to v5 yet and hence, I receive a lot of questions regarding testing in v5. In this article, **I will show you, how to setup [japa](https://github.com/thetutlage/japa) to test your AdonisJS applications.**

--- a/content/guides/auth/social.md
+++ b/content/guides/auth/social.md
@@ -251,7 +251,7 @@ Also, for some of the drivers (e.g., Google), the list of the scopes is too long
 :::warning
 
 If you want to customize the Discord driver, it require to have the `identify` scope present to work properly.
-You can find more informations about it [here](https://discord.com/developers/docs/resources/user#get-current-user).
+You can find more information about it [here](https://discord.com/developers/docs/resources/user#get-current-user).
 
 :::
 

--- a/content/guides/introduction.md
+++ b/content/guides/introduction.md
@@ -55,7 +55,7 @@ We also encourage you to help others whenever possible 💗
 - [Awesome AdonisJS](https://github.com/adonisjs-community/awesome-adonisjs) - A collection of packages, tutorials and applications created by the community members.
 
 ## Who maintains AdonisJS?
-AdonisJS is primarly maintained by [Harminder Virk](https://twitter.com/AmanVirk1) (the creator and the lead maintainer of the framework) along with the help of the following core team members.
+AdonisJS is primarily maintained by [Harminder Virk](https://twitter.com/AmanVirk1) (the creator and the lead maintainer of the framework) along with the help of the following core team members.
 
 - [Romain Lanz](https://twitter.com/romainlanz) is a full-stack developer at the FIVB. He believes that knowledge should be free and accessible for anyone, and he is working towards it.
 - [Michaël Zasso](https://twitter.com/targos89) is a scientific research software engineer and a member of the Node.js Technical Steering Committee.

--- a/content/guides/models/factories.md
+++ b/content/guides/models/factories.md
@@ -145,7 +145,7 @@ user.posts.length // 3
 ### Points to note
 - The factory will find the type of relationship by inspecting the Lucid model. For example: If your model defines a `hasMany` relationship on `posts`, then factory will infer the same.
 - A relationship first needs to be defined on the model and then only it can be defined on the Factory.
-- Lucid will internally wrap all the database operations inside a transaction. So if a relationship persistance fails, the parent model persistance will be rolled back too.
+- Lucid will internally wrap all the database operations inside a transaction. So if a relationship persistence fails, the parent model persistence will be rolled back too.
 
 ### Applying relationship states
 You can also apply states on a relationship by passing a callback to the `with` method.

--- a/content/guides/testing/http-tests.md
+++ b/content/guides/testing/http-tests.md
@@ -59,7 +59,7 @@ test('get a paginated list of existing posts', async ({ client }) => {
 - The assertion will use the **request method**, the **endpoint** and **response status code** to find the expected response schema.
 - The actual response body is validated against the matching schema. 
 
-Do note, only the shape of the response is tested and not the actual values. Therefore, you may have to write additonal assertions. For example:
+Do note, only the shape of the response is tested and not the actual values. Therefore, you may have to write additional assertions. For example:
 
 ```ts
 // Assert that response is as per the schema

--- a/content/reference/i18n/i18n-manager.md
+++ b/content/reference/i18n/i18n-manager.md
@@ -147,7 +147,7 @@ Event.on('i18n:missing:translation', I18n.prettyPrint)
 Extend the default capabilities by adding custom formatters and translations loaders.
 
 :::note
-Make sure to read the [extensions guide](../../guides/digging-deeper/i18n.md#add-custom-message-formatter) for an in-depth explaination for adding custom formatters and loaders.
+Make sure to read the [extensions guide](../../guides/digging-deeper/i18n.md#add-custom-message-formatter) for an in-depth explanation for adding custom formatters and loaders.
 :::
 
 ```ts

--- a/content/reference/validator/rules/url.md
+++ b/content/reference/validator/rules/url.md
@@ -66,7 +66,7 @@ Following is the list of options for validate a URL string
 | `requireHost` | Ensure the URL has the host defined. Defaults to `true` |
 | `allowedHosts` | An array of allowed hosts. URLs outside the defined hosts will fail the validation. |
 | `bannedHosts` | An array of banned hosts. URLs matching the defined hosts will fail the validation. |
-| `validateLength` | Validate the length of the URL to be under or equal to **2083 charcters**. Defaults to `true`. |
+| `validateLength` | Validate the length of the URL to be under or equal to **2083 characters**. Defaults to `true`. |
 
 ## Normalizing url
 You can normalize the URL using the `rules.normalizeUrl` method.


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `content/cookbooks/auth/using-ally-with-api-guard.md`
1 typo in `content/cookbooks/database/using-postgres-custom-type-parsers.md`
2 typos in `content/cookbooks/deployment/laravel-forge.md`
1 typo in `content/cookbooks/testing-adonisjs-apps.md`
1 typo in `content/guides/auth/social.md`
1 typo in `content/guides/introduction.md`
1 typo in `content/guides/models/factories.md`
1 typo in `content/guides/testing/http-tests.md`
1 typo in `content/reference/i18n/i18n-manager.md`
1 typo in `content/reference/validator/rules/url.md`


Best!