### PR TITLE
fix: small typo on Line 41 in middleware.md

### DIFF
--- a/content/guides/auth/middleware.md
+++ b/content/guides/auth/middleware.md
@@ -38,7 +38,7 @@ The silent auth middleware silently checks if the user is logged-in or not. The 
 
 This middleware is helpful when you want to render a public webpage, but also show the currently logged in user details somewhere in the page (maybe the header).
 
-To summarize, this middleware does not force the users to be logged-in, but will fetch their details if they are logged-in and provide it you through out the request lifecycle.
+To summarize, this middleware does not force the users to be logged-in, but will fetch their details if they are logged-in and provide it to you through out the request lifecycle.
 
 If you plan to use this middleware, then you must register it inside the list of global middleware.
 


### PR DESCRIPTION
### 🔗 Linked issue
N/A

### ❓ Type of change
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This PR will fix a typo in the Auth Middleware documentation page. 
I have added the missing "to" on line 41 which I believe was a typo.

### 📝 Checklist
- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
