### PR TITLE
Updated `sendfile_max_chunk` to `2m`

### DIFF
--- a/content/guides/fundamentals/deployment.md
+++ b/content/guides/fundamentals/deployment.md
@@ -210,7 +210,7 @@ Add the following block to your NGINX config file. **Make sure to replace the va
 location ~ \.(jpg|png|css|js|gif|ico|woff|woff2) {
   root <PATH_TO_ADONISJS_APP_PUBLIC_DIRECTORY>;
   sendfile on;
-  sendfile_max_chunk 2mb;
+  sendfile_max_chunk 2m;
   add_header Cache-Control "public";
   expires 365d;
 }


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Changed the unit of measure of `sendfile_max_chunk` to `2m`, previously `2mb`. The `mb` is a wrong unit of measure and nginx throws an error, see more on nginx documentation https://nginx.org/en/docs/syntax.html

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
