### PR TITLE
fix: replacing deprecated flag at the end of TypeScript build process page

### DIFF
--- a/content/guides/fundamentals/typescript-build-process.md
+++ b/content/guides/fundamentals/typescript-build-process.md
@@ -94,6 +94,6 @@ Creating a standalone `build` folder does help in reducing the size of code that
 - You must install production-only dependencies inside the `build` folder.
   ```sh
   cd build
-  npm ci --production
+  npm ci --omit=dev
   ```
 - We do not copy the `.env` file to the output folder. Because the environment variables are not transferable, you must define environment variables for production separately.


### PR DESCRIPTION
### ❓ Type of change
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Replacing `npm ci --production` flag by `--only=dev` because `--production` has been deprecated:

```shell
$ npm ci --production
npm WARN config production Use `--omit=dev` instead.
```